### PR TITLE
Add nasus.io to NFT data subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you see something missing - please submit a PR 🙏
 - [NFT FloorPrice](https://nftfloorprice.vercel.app/) - another app to track floor prices (shows by Marketplace).  
 - [Solana Seer](https://solseer.app/) - see floor prices for each NFT in your wallet (includes those currently selling on marketplaces).
 - [CryptoSlam](https://cryptoslam.io/) - useful multi-chain analytics, has all the top collections on Solana 
-- [NASUS](https://nasus.io/) - portfolio management focused NFT viewer
+- [Nasus](https://nasus.io/) - portfolio management focused NFT viewer
 
 ### Rarity
 - [How Rare Is](https://howrare.is/) - rarity tools for NFTs on solana.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If you see something missing - please submit a PR 🙏
 - [NFT FloorPrice](https://nftfloorprice.vercel.app/) - another app to track floor prices (shows by Marketplace).  
 - [Solana Seer](https://solseer.app/) - see floor prices for each NFT in your wallet (includes those currently selling on marketplaces).
 - [CryptoSlam](https://cryptoslam.io/) - useful multi-chain analytics, has all the top collections on Solana 
+- [NASUS](https://nasus.io/) - portfolio management focused NFT viewer
 
 ### Rarity
 - [How Rare Is](https://howrare.is/) - rarity tools for NFTs on solana.


### PR DESCRIPTION
GM Ser Ilmoi,

I would like to submit for your consideration my new site, [nasus.io](nasus.io). It simply allows NFT traders to punch in a wallet address, and see all their NFTs (not just what's in their wallet, but also listed on exchanges as well). 

![image](https://user-images.githubusercontent.com/76828686/142712140-bce847b5-8cfa-433e-8d0a-6fd22404c4e2.png)

It also includes a rudimentary consolidated trade history, which I haven't seen elsewhere:

![image](https://user-images.githubusercontent.com/76828686/142708444-63445169-7f5e-4a1d-a6f4-780c39c0eed0.png)

Kind regards,
NTM