### PR TITLE
Added nearingnft.net, removed upcomingnft.art

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ If you see something missing - please submit a PR 🙏
 - [Non Fungi](https://www.non-fungi.com/solana-nft-drops/) - multi-chain drop info, includes Solana (filterable)
 - [NFT Calendar](https://nftcalendar.io/b/solana/) - multi-chain drop info, includes Solana (filterable)
 - [Ape O'Clock](https://www.apeoclock.com/all-sol-launches/) - multi-chain drop info, includes Solana (filterable)
+- [NearingNFT](https://www.nearingnft.net/) - multi-chain drop info, includes Solana (filterable)
 - [Rarity Tools](https://rarity.tools/upcoming/) - multi-chain drop info, includes Solana
 - [NFT Evening](https://nftevening.com/calendar/) - multi-chain drop info, includes Solana
-- [Upcoming NFT](https://upcomingnft.art/) - multi-chain drop info, includes Solana
 - [CoinMarketCap](https://coinmarketcap.com/nft/upcoming/) - multi-chain drop info, includes Solana
 - [NFT Drop Scanner](https://nftdropscanner.com) - multi-chain drop info, includes Solana
 - [NFT Sailing](https://nftsailing.net) - multi-chain drop info, includes Solana (filterable)


### PR DESCRIPTION
Added NFT Calendar 'nearingnft.net'. The NFT Calendar 'upcomingnft.art' seems to be down, so consider removing it, same with 'nextdrop.is' (as of writing).