### PR TITLE
GetBlock to the list of RPC providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ If you see something missing - please submit a PR 🙏
 - [Syndica](https://syndica.io/)
 - [NOWNodes](https://nownodes.io)
 - [Node Monkey](https://marketplace.nodemonkey.io/)
+- [GetBlock](https://getblock.io/nodes/sol/)
 
 ## 🔗 Related Awesome Lists
 


### PR DESCRIPTION
The previous pull request was with a wrong link https://getblock.io/nodes/sol/