### PR TITLE
Add GetBlock to the list of RPC providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ If you see something missing - please submit a PR 🙏
 ## ⚙️ RPC Providers
 
 - [GenesysGo](https://genesysgo.com/)
+- [GetBlock](https://getblock.io/)
 - [QuickNode](https://quicknode.com/)
 - [RunNode](https://runnode.com/)
 - [Triton One | RPC Pool](https://triton.one/#/)


### PR DESCRIPTION
GetBlock supports Solana network as a node provider